### PR TITLE
Feature Postback url

### DIFF
--- a/docker/test/Dockerfile
+++ b/docker/test/Dockerfile
@@ -19,4 +19,4 @@ WORKDIR /src
 
 COPY docker/test/xdebug.ini /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
 
-CMD /bin/bash
+CMD tail -f /src/composer.json

--- a/src/ContactCenter.php
+++ b/src/ContactCenter.php
@@ -103,7 +103,7 @@ class ContactCenter
         return $this->emailTemplateManager;
     }
 
-    public function createEmailMessage() : EmailMessage
+    public function createEmailMessage()
     {
         $emailMessage = new EmailMessage($this->clientHttp);
         $emailMessage->setConfig($this->config);

--- a/src/ContactCenter.php
+++ b/src/ContactCenter.php
@@ -103,7 +103,7 @@ class ContactCenter
         return $this->emailTemplateManager;
     }
 
-    public function createEmailMessage()
+    public function createEmailMessage() : EmailMessage
     {
         $emailMessage = new EmailMessage($this->clientHttp);
         $emailMessage->setConfig($this->config);

--- a/src/Entities/Postback.php
+++ b/src/Entities/Postback.php
@@ -5,15 +5,13 @@ namespace Eduzz\ContactCenter\Entities;
 class Postback
 {
     private $method;
-    private $protocol;
     private $url;
     private $headers;
 
-    public function __construct(string $method, string $url, string $protocol = 'http', array $headers)
+    public function __construct(string $method, string $url, array $headers)
     {
         $this->method = $method;
         $this->url  = $url;
-        $this->protocol  = $protocol;
         $this->headers  = $headers;
     }
 
@@ -21,7 +19,6 @@ class Postback
     {
         $data['method'] = $this->method;
         $data['url'] = $this->url;
-        $data['protocol'] = $this->protocol;
         if ($this->headers) {
             $data['headers'] = $this->headers;
         }

--- a/src/Entities/Postback.php
+++ b/src/Entities/Postback.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Eduzz\ContactCenter\Entities;
+
+class Postback
+{
+    private $method;
+    private $protocol;
+    private $url;
+    private $headers;
+
+    public function __construct(string $method, string $url, string $protocol = 'http', array $headers)
+    {
+        $this->method = $method;
+        $this->url  = $url;
+        $this->protocol  = $protocol;
+        $this->headers  = $headers;
+    }
+
+    public function toArray()
+    {
+        $data['method'] = $this->method;
+        $data['url'] = $this->url;
+        $data['protocol'] = $this->protocol;
+        if ($this->headers) {
+            $data['headers'] = $this->headers;
+        }
+        return $data;
+    }
+}

--- a/src/Messages/EmailMessage.php
+++ b/src/Messages/EmailMessage.php
@@ -3,6 +3,7 @@
 namespace Eduzz\ContactCenter\Messages;
 
 use Eduzz\ContactCenter\Entities\Person;
+use Eduzz\ContactCenter\Entities\Postback;
 use Eduzz\ContactCenter\Messages\Message;
 use Eduzz\ContactCenter\Traits\Configuration;
 use GuzzleHttp\Client;
@@ -20,18 +21,20 @@ class EmailMessage extends Message
     private $from;
     private $params;
     private $subject;
+    private $postback;
 
     public function __construct(Client $clientHttp)
     {
         $this->clientHttp = $clientHttp;
 
-        $this->from    = null;
-        $this->params  = [];
-        $this->subject = null;
-        $this->to      = [];
-        $this->cc      = [];
-        $this->bcc     = [];
-        $this->replyTo = null;
+        $this->from     = null;
+        $this->params   = [];
+        $this->subject  = null;
+        $this->to       = [];
+        $this->cc       = [];
+        $this->bcc      = [];
+        $this->replyTo  = null;
+        $this->postback = null;
     }
 
     public function to(array $to)
@@ -90,6 +93,12 @@ class EmailMessage extends Message
         return $this;
     }
 
+    public function postback(Postback $postback)
+    {
+        $this->postback = $postback->toArray();
+        return $this;
+    }
+
     private function prepareData()
     {
         $data['template_id'] = $this->template;
@@ -124,6 +133,10 @@ class EmailMessage extends Message
 
         if ($this->metadata) {
             $data['_metadata'] = $this->metadata;
+        }
+
+        if ($this->postback) {
+            $data['postback'] = $this->postback;
         }
 
         return $data;

--- a/tests/Messages/SMSMessageTest.php
+++ b/tests/Messages/SMSMessageTest.php
@@ -44,7 +44,7 @@ class SMSMessageTest extends TestCase
         $smsMessage = new SMSMessage($this->clientHttp);
 
         $response = $smsMessage->to([
-            (new Phone('+55', '15', '999999999'))->toArray(),
+            (new Phone('+55', '15', '999999999')),
         ])
             ->params([
                 'nome' => 'PHPUnit',


### PR DESCRIPTION
Adiciona recurso de Postback na chamada do Email message. Agora, é possível chamar a função da seguinte forma:
```
$contactcenter
->createEmailMessage()
->to([ new Person('teste@gmail.com', 'Diogo')])
->template('2jne2jenee2ne32je')
->postback(new Postback('POST', 'http://teste.meudominio.com/postback', ['Authorization' => '123']))
->send();
```

Novo recurso de postback agora permite que o Contact Center faça tentativas de postbacks para a url passada. O serviço tentará no máximo 5 vezes até deixar de enviar.